### PR TITLE
Change C1+C1 to C1+C2

### DIFF
--- a/8_geometry/README.md
+++ b/8_geometry/README.md
@@ -51,7 +51,7 @@ Any non-zero vector $\mathbf{x}$ can be used to define a unit vector in the dire
 
 Given a vector space $X$ a function $d:X \rightarrow \Bbb{R}$ is a _norm_ if it satisfies
 - Triangle inequality. $d(\mathbf{x} + \mathbf{y}) \leq d(\mathbf{x}) + d(\mathbf{y})$ for all $\mathbf{x},\mathbf{y} \in X$
-- Absolute homogeneity. $d(s\mathbf{x}) = |s|d(\mathbf{x})$ for all $\mathbf{x} \in X$ and scalars $s$
+- Absolute homogeneity. $d(s\mathbf{x}) = |s|d(\mathbf{x})$ or all $\mathbf{x} \in X$ and scalars $s$
 - Positive definite. If $d(\mathbf{x}) = 0$ then $\mathbf{x} = \mathbf{0}$
 
 
@@ -114,7 +114,7 @@ What happens if $p \rightarrow 0$?
 
 `$$\lim_{p\to 0} x^p = 1$$`
 
-`$$\lim_{p\to 0} \| \mathbf{x} \|_p = \infty$$`
+`$$\lim_{p\to 0} \| \mathbf{x} \| = \infty$$`
 
 But (assuming $0^0=0$), can define $\ell_0$ as
 


### PR DESCRIPTION
Minor error correction for the Readme.md file changing a line under the 'Properties of dot product' subheading, changing C1+C1 to C1+C2.